### PR TITLE
Remove phone numbers from blog archive posts

### DIFF
--- a/_posts/2010-11-01-2011-fellows-announcement.md
+++ b/_posts/2010-11-01-2011-fellows-announcement.md
@@ -41,8 +41,6 @@ Biographies of the 2011 Code for America fellows are available here: <http://cod
   
 Abhi Nemani, Code for America
   
-618-322-2220
-  
 abhi@codeforamerica.org
 
 ###

--- a/_posts/2010-12-08-2012city-app-release.md
+++ b/_posts/2010-12-08-2012city-app-release.md
@@ -30,6 +30,6 @@ Applications for the 2012 City Program are available online now and will be acce
 
 Contact Information
   
-For media inquiries, please contact: Abhi Nemani, 618-322-2220, <abhi@codeforamerica.org>
+For media inquiries, please contact: Abhi Nemani <abhi@codeforamerica.org>
   
 ###

--- a/_posts/2011-02-09-application-deadline-approaching-for-2012-code-for-america-city-program.md
+++ b/_posts/2011-02-09-application-deadline-approaching-for-2012-code-for-america-city-program.md
@@ -31,6 +31,6 @@ Code for America (CfA) connects the talent of the tech industry with local gover
   
 Contact Information
   
-For media inquiries, please contact: Abhi Nemani, 618-322-2220, abhi@codeforamerica.org
+For media inquiries, please contact: Abhi Nemani, abhi@codeforamerica.org
 
 ###

--- a/_posts/2011-03-08-2012cityapps.md
+++ b/_posts/2011-03-08-2012cityapps.md
@@ -89,6 +89,6 @@ Code for America enlists the brightest minds of the web industry into public ser
   
 Contact Information
   
-For media inquiries, please contact: Abhi Nemani, 618-322-2220, <abhi@codeforamerica.org>
+For media inquiries, please contact: Abhi Nemani, <abhi@codeforamerica.org>
 
 ###

--- a/_posts/2011-03-21-code-for-america-opens-applications-for-2012-fellowship-launches-early-decision-program.md
+++ b/_posts/2011-03-21-code-for-america-opens-applications-for-2012-fellowship-launches-early-decision-program.md
@@ -27,6 +27,6 @@ Code for America (CfA) connects the talent of the tech industry with local gover
 
 Contact Information
   
-For media inquiries, please contact: Abhi Nemani, 618-322-2220, abhi@codeforamerica.org
+For media inquiries, please contact: Abhi Nemani, abhi@codeforamerica.org
 
 ###

--- a/_posts/2011-03-30-itdb.md
+++ b/_posts/2011-03-30-itdb.md
@@ -187,6 +187,6 @@ The code is available and open at http://sourceforge.net/projects/it-dashboard, 
 
 **Contact Information**
   
-For media inquiries, please contact: Abhi Nemani, 618-322-2220, abhi@codeforamerica.org
+For media inquiries, please contact: Abhi Nemani, abhi@codeforamerica.org
 
 ###

--- a/_posts/2011-07-08-chicago-2012-finalist-announcement.md
+++ b/_posts/2011-07-08-chicago-2012-finalist-announcement.md
@@ -59,9 +59,9 @@ Code for America (CfA) connects the talent of the tech industry with local gover
 
 For more information contact:
 
-Abhi Nemani, Code for America, <abhi@codeforamerica.org>, 9092062220
+Abhi Nemani, Code for America, <abhi@codeforamerica.org>
 
-Kathleen Strand, City of Chicago, <kathleen.strand@cityofchicago>, 312-744-9045
+Kathleen Strand, City of Chicago, <kathleen.strand@cityofchicago>
 
 <p align="center">
   ###

--- a/_posts/2011-09-07-knight-brings-cfa-to-detroit-macon-and-philly.md
+++ b/_posts/2011-09-07-knight-brings-cfa-to-detroit-macon-and-philly.md
@@ -45,9 +45,9 @@ The 2012 Code for America fellows will begin their fellowship in January 2012, a
 
 For more information contact:
   
-[Abhi Nemani](http://abhinemani.com/), Code for America, abhi@codeforamerica.org, 909-206-2220
+[Abhi Nemani](http://abhinemani.com/), Code for America, abhi@codeforamerica.org
   
-Marc Fest, John S. and James L. Knight Foundation, <fest@knightfoundation.org>;, 305-908-2677
+Marc Fest, John S. and James L. Knight Foundation, <fest@knightfoundation.org>
 
 <p dir="ltr">
   ###

--- a/_posts/2011-11-20-change-by-us-goes-open-source-launches-in-philly.md
+++ b/_posts/2011-11-20-change-by-us-goes-open-source-launches-in-philly.md
@@ -53,6 +53,6 @@ The source code and instructions for installation are available for download on 
 
 Contact:
 
-  * Jake Barton, Local Projects, +1 212 480 0479, jake@localprojects.net
-  * Julia Klaiber, CEOs for Cities, +1 202 420 9451, jklaiber@ceosforcities.org
-  * Abhi Nemani, Code for America, +1 909 206 2220, abhi@codeforamerica.org
+  * Jake Barton, Local Projects, jake@localprojects.net
+  * Julia Klaiber, CEOs for Cities, jklaiber@ceosforcities.org
+  * Abhi Nemani, Code for America, abhi@codeforamerica.org


### PR DESCRIPTION
This commit is a first pass at removing personal phone numbers from the
CfA blog archive. It related to concerns raised by a former employee
around receiving numerous unsolicited phone calls.