### PR TITLE
Link Blog Archive logo to main CfA website

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <section class="header">
   <div class="container">
     <div class="header-logo">
-      <a href="{{ site.baseurl }}/">
+      <a href="https://www.codeforamerica.org">
         <img src="{{ site.baseurl }}/images/cfa-logo.png" />
       </a>
       <a class="header-logo-tagline" href="{{ site.baseurl }}/">


### PR DESCRIPTION
The current link is broken. This changes out the link so it points to the main CfA website.