### PR TITLE
Add Google Analytics tracking code

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,6 +59,17 @@
   <script src="https://use.typekit.net/lkd6vsz.js"></script>
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
+  <!-- Google Analytics -->
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    ga('create', 'UA-20825280-1', 'auto');
+    ga('require', 'linkid', 'linkid.js');
+    ga('send', 'pageview');
+  </script>
+
   <!-- Shims -->
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.4.2/respond.min.js"></script>


### PR DESCRIPTION
At the moment, we're not tracking the Blog Archive with Google Analytics, so we don't really know
much about our users on there. This commit adds the CfA site GA tracking code.